### PR TITLE
CFAST Correct Incident flux used to judge fire ignition to be consist…

### DIFF
--- a/Source/CFAST/cfast_data.f90
+++ b/Source/CFAST/cfast_data.f90
@@ -60,7 +60,7 @@ module fire_data
     integer :: ifroom(mxfires)                      ! room fire is located in (sorted by room number)
     
     integer :: objign(mxfires)                      ! ignition type for each fire (1 = time, 2 = temperature, 3 = heat flux)
-    real(eb), dimension(3,mxfires) :: objcri        ! ignition criteria for each fire (1 = time, 2 = flux, 3 = temperature)
+    real(eb), dimension(3,mxfires) :: objcri        ! ignition criteria for each fire (1 = time, 2 = temperature, 3 = heat flux)
 
     integer, dimension(mxfires) :: objlfm           ! actual number of time points for each fire
     real(eb), dimension(mxpts,mxfires) :: otime     ! time points for fire inputs

--- a/Source/CFAST/cfast_structures.f90
+++ b/Source/CFAST/cfast_structures.f90
@@ -152,8 +152,8 @@ module cfast_types
         real(eb) :: thickness           ! target thickness (from matching thermal properties input)
         real(eb) :: depth_loc           ! depth location for output of internal temperature
                                         !       (from user input with default of 0.5*thickness)
-        real(eb) :: flux_front          ! incident heat flux to front surface of target (calculated)
-        real(eb) :: flux_back           ! incident heat flux to back surface of target (calculated)
+        real(eb) :: flux_incident_front ! incident heat flux to front surface of target (calculated)
+        real(eb) :: flux_incident_back  ! incident heat flux to back surface of target (calculated)
         real(eb) :: flux_net_front      ! net heat flux to front surface of target (calculated)
         real(eb) :: flux_net_back       ! net heat flux to back surface of target (calculated)
         real(eb), dimension(nnodes_trg) :: temperature  ! target temperatures from front to back

--- a/Source/CFAST/fire.f90
+++ b/Source/CFAST/fire.f90
@@ -1252,11 +1252,11 @@ module fire_routines
                 end if
             else if (ignflg==2) then
                 targptr => targetinfo(itarg)
-                call check_object_ignition(told,dt,targptr%temperature(idx_tempf_trg),objcri(3,i),obcond(igntemp,i),&
+                call check_object_ignition(told,dt,targptr%temperature(idx_tempf_trg),objcri(2,i),obcond(igntemp,i),&
                    i,ifobj,tobj,tmpob(1,i))
             else if (ignflg==3) then
                 targptr => targetinfo(itarg)
-                call check_object_ignition(told,dt,targptr%flux_front,objcri(2,i),obcond(ignflux,i),&
+                call check_object_ignition(told,dt,targptr%flux_incident_front,objcri(3,i),obcond(ignflux,i),&
                    i,ifobj,tobj,tmpob(1,i))
             else
                 call xerror('Update_fire_objects-incorrectly defined ignition type in input file',0,1,1)
@@ -1273,7 +1273,7 @@ module fire_routines
                 if (ignflg>1) then
                     targptr => targetinfo(itarg)
                     obcond(igntemp,i) = targptr%temperature(idx_tempf_trg)
-                    obcond(ignflux,i) = targptr%flux_front
+                    obcond(ignflux,i) = targptr%flux_incident_front
                 end if
                 if (iflag==set_detector_state.and.tmpob(1,i)>0.0_eb) then
                     if (tmpob(2,i)<=tobj) then

--- a/Source/CFAST/input.f90
+++ b/Source/CFAST/input.f90
@@ -786,8 +786,6 @@ module input_routines
             fireptr%name = lcarray(11)
             objon(n_fires) = .false.
             ! Note that ignition type 1 is time, type 2 is temperature and 3 is flux
-            ! The critiria for temperature and flux are stored backupwards - this is historical
-            ! See corresponding code in update_fire_objects
             if (tmpcond>0.0_eb) then
                 if (objign(n_fires)==1) then
                     objcri(1,n_fires) = tmpcond
@@ -795,12 +793,12 @@ module input_routines
                     objcri(3,n_fires) = 1.0e30_eb
                 else if (objign(n_fires)==2) then
                     objcri(1,n_fires) = 1.0e30_eb
-                    objcri(2,n_fires) = 1.0e30_eb
-                    objcri(3,n_fires) = tmpcond
-                else if (objign(n_fires)==3) then
-                    objcri(1,n_fires) = 1.0e30_eb
                     objcri(2,n_fires) = tmpcond
                     objcri(3,n_fires) = 1.0e30_eb
+                else if (objign(n_fires)==3) then
+                    objcri(1,n_fires) = 1.0e30_eb
+                    objcri(2,n_fires) = 1.0e30_eb
+                    objcri(3,n_fires) = tmpcond
                 else
                     write(*,5358) objign(n_fires)
                     write(logerr,5358) objign(n_fires)

--- a/Source/CFAST/output.f90
+++ b/Source/CFAST/output.f90
@@ -486,7 +486,7 @@ module output_routines
     integer, intent(in) :: itprt
 
     integer :: i, iw, itarg
-    real(eb) :: ctotal, total, ftotal, wtotal, gtotal, tgtemp, tttemp, tctemp
+    real(eb) :: ctotal, total, ftotal, wtotal, gtotal, itotal, tgtemp, tttemp, tctemp
 
     type(target_type), pointer :: targptr
     type(room_type), pointer :: roomptr
@@ -514,21 +514,26 @@ module output_routines
                     wtotal = targptr%flux_surface(1)
                     gtotal = targptr%flux_gas(1)
                     ctotal = targptr%flux_convection_gauge(1)
+                    itotal = targptr%flux_incident_front
                 else
                     total = targptr%flux_net(1)
                     ftotal = targptr%flux_fire(1)
                     wtotal = targptr%flux_surface(1)
                     gtotal = targptr%flux_gas(1)
                     ctotal = targptr%flux_convection(1)
+                    itotal = targptr%flux_incident_front
                 end if
-                if (total<=1.0e-10_eb) total = 0.0_eb
-                if (ftotal<=1.0e-10_eb) ftotal = 0.0_eb
-                if (wtotal<=1.0e-10_eb) wtotal = 0.0_eb
-                if (gtotal<=1.0e-10_eb) gtotal = 0.0_eb
-                if (ctotal<=1.0e-10_eb) ctotal = 0.0_eb
+                if (abs(total)<=1.0e-10_eb) total = 0.0_eb
+                if (abs(ftotal)<=1.0e-10_eb) ftotal = 0.0_eb
+                if (abs(wtotal)<=1.0e-10_eb) wtotal = 0.0_eb
+                if (abs(gtotal)<=1.0e-10_eb) gtotal = 0.0_eb
+                if (abs(ctotal)<=1.0e-10_eb) ctotal = 0.0_eb
                 if (total/=0.0_eb) then
                     write(iofilo,5020) targptr%name, tgtemp-kelvin_c_offset, tttemp-kelvin_c_offset, &
-                        tctemp-kelvin_c_offset, total, ftotal, wtotal, gtotal, ctotal
+                        tctemp-kelvin_c_offset, itotal, total, ftotal, wtotal, gtotal, ctotal
+                elseif (itotal/=0.0_eb) then
+                    write(iofilo,5030) targptr%name, tgtemp-kelvin_c_offset, tttemp-kelvin_c_offset, tctemp-kelvin_c_offset, &
+                        itotal
                 else
                     write(iofilo,5020) targptr%name, tgtemp-kelvin_c_offset, tttemp-kelvin_c_offset, tctemp-kelvin_c_offset
                 end if
@@ -539,13 +544,14 @@ module output_routines
     return
 5000 format (//,'SURFACES AND TARGETS',//, &
     'Compartment    Ceiling   Up wall   Low wall  Floor    Target        Gas       ', &
-    'Surface   Interior Flux To      Fire         Surface      Gas',/, &
+    'Surface   Interior Incident     Net          Fire         Surface      Gas',/, &
     '               Temp.     Temp.     Temp.     Temp.                  Temp.     ', &
-    'Temp.     Temp.    Target       Rad.         Rad.         Rad.         Convect.',/, &
+    'Temp.     Temp.    Flux         Flux         Rad.         Rad.         Rad.         Convect.',/, &
     '               (C)       (C)       (C)       (C)                    (C)       ', &
-         '(C)       (C)      (W/m^2)      (W/m^2)      (W/m^2)      (W/m^2)      (W/m^2)      ',/,158('-'))
+         '(C)       (C)      (W/m^2)      (W/m^2)      (W/m^2)      (W/m^2)      (W/m^2)      (W/m^2)',/,172('-'))
 5010 format (a14,4(1pg10.3))
-5020 format (54x,a8,4x,3(1pg10.3),1x,5(1pg10.3,3x))
+5020 format (54x,a8,4x,3(1pg10.3),1x,6(1pg10.3,3x))
+5030 format (54x,a8,4x,3(1pg10.3),66x,1pg10.3)
     end subroutine results_targets
 
 ! --------------------------- results_detectors -------------------------------------------

--- a/Source/CFAST/outputspreadsheet.f90
+++ b/Source/CFAST/outputspreadsheet.f90
@@ -213,7 +213,7 @@ module spreadsheet_routines
 
     !     Output the temperatures and fluxes on surfaces and targets at the current time
 
-    integer, parameter :: maxoutput=4*mxrooms+26*mxtarg+4*mxdtect
+    integer, parameter :: maxoutput=4*mxrooms+27*mxtarg+4*mxdtect
     real(eb), intent(in) :: time
 
     real(eb) :: outarray(maxoutput), zdetect, tjet, vel, tlink, xact
@@ -261,6 +261,7 @@ module spreadsheet_routines
         call SSaddtolist (position, tttemp-kelvin_c_offset, outarray)
         call SSaddtolist (position, tctemp-kelvin_c_offset, outarray)
         ! front surface
+        call SSaddtolist (position, targptr%flux_incident_front / 1000._eb, outarray)
         call SSaddtolist (position, targptr%flux_net(1) / 1000._eb, outarray)
         call SSaddtolist (position, targptr%flux_radiation(1) / 1000._eb, outarray)
         call SSaddtolist (position, targptr%flux_convection(1) / 1000._eb, outarray)

--- a/Source/CFAST/solve.f90
+++ b/Source/CFAST/solve.f90
@@ -779,7 +779,7 @@ module solve_routines
         if (ifobj>0.and.tobj<=td) then
             fireptr => fireinfo(ifobj)
             call update_fire_objects (set_detector_state,told,dt,ifobj,tobj)
-            write(iofilo,'(a,i0,3a,i0,a)') 'Object #',ifobj,' (',trim(fireptr%name),') ignited at ', &
+            write(iofilo,'(/,a,i0,3a,i0,a)') 'Object #',ifobj,' (',trim(fireptr%name),') ignited at ', &
                 int(max(tobj+0.5_eb,0.0_eb)),' seconds'
             write(*,'(a,i0,3a,i0,a)') 'Object #',ifobj,' (',trim(fireptr%name),') ignited at ', &
                 int(max(tobj+0.5_eb,0.0_eb)),' seconds'

--- a/Source/CFAST/ssHeaders.f90
+++ b/Source/CFAST/ssHeaders.f90
@@ -187,8 +187,8 @@ module spreadsheet_header_routines
     !.....  sensor number
     !.....  compartment name, type, sensor temperature, activated, smoke temperature, smoke velocity
 
-    integer, parameter :: maxhead = 1+9*mxrooms+14*mxtarg+4*mxdtect
-    character(35) :: headertext(4,maxhead), cTemp, cType, cDet, cRoom, Labels(23), LabelsShort(23), LabelUnits(23), frontorback(2)
+    integer, parameter :: maxhead = 1+9*mxrooms+15*mxtarg+4*mxdtect
+    character(35) :: headertext(4,maxhead), cTemp, cType, cDet, cRoom, Labels(24), LabelsShort(24), LabelUnits(24), frontorback(2)
     integer position, i, j, itarg, itype
     type(room_type), pointer :: roomptr
     type(target_type), pointer :: targptr
@@ -196,18 +196,18 @@ module spreadsheet_header_routines
 
     data Labels / 'Time', 'Ceiling Temperature', 'Upper Wall Temperature', 'Lower Wall Temperature', 'Floor Temperature', &
         'Target Surrounding Gas Temperature', 'Target Surface Temperature', 'Target Center Temperature', &
-        'Target Total Flux', 'Target Radiative Flux', 'Target Convective Flux', 'Target Fire Radiative Flux', &
-        'Target Surface Radiative Flux', 'Target Gas Radiative Flux', 'Target Radiative Loss Flux', &
-        'Target Total Gauge Flux', 'Target Radiative Gauge Flux', 'Target Convective Gauge Flux', &
+        'Target Incident Flux','Target Net Flux', 'Target Radiative Flux', 'Target Convective Flux', &
+        'Target Fire Radiative Flux', 'Target Surface Radiative Flux', 'Target Gas Radiative Flux', &
+        'Target Radiative Loss Flux', 'Target Total Gauge Flux', 'Target Radiative Gauge Flux', 'Target Convective Gauge Flux', &
         'Target Radiative Loss Gauge Flux',  &
         'Sensor Temperature', 'Sensor Activation', 'Sensor Surrounding Gas Temperature', 'Sensor Surrounding Gas Velocity' /
 
     data LabelsShort /'Time', 'CEILT_', 'UWALLT_', 'LWALLT_', 'FLOORT_', &
-        'TRGGAST_', 'TRGSURT_', 'TRGCENT_', 'TRGFLXT_', 'TRGFLXR_', &
+        'TRGGAST_', 'TRGSURT_', 'TRGCENT_', 'TRGFLXI_', 'TRGFLXT_', 'TRGFLXR_', &
         'TRGFLXC_','TRGFLXF_', 'TRGFLXS_', 'TRGFLXG_', 'TRGFLXRE_', 'TRGFLXTG_', 'TRGFLXRG_', 'TRGFLXCG_', 'TRGFLXREG_',  &
         'SENST_', 'SENSACT_', 'SENSGAST_', 'SENSGASVEL_' /
 
-    data LabelUnits / 's', 7*'C', 11*'KW/m^2', 'C', '1=yes', 'C', 'm/s' /
+    data LabelUnits / 's', 7*'C', 12*'KW/m^2', 'C', '1=yes', 'C', 'm/s' /
     data frontorback / '','B_'/
 
     !  spreadsheet header.  Add time first
@@ -235,7 +235,7 @@ module spreadsheet_header_routines
         call toIntString(itarg,cDet)
         targptr => targetinfo(itarg)
         ! front surface
-        do j = 1, 14
+        do j = 1, 15
             position = position + 1
             headertext(1,position) = trim(frontorback(1)) // trim(LabelsShort(j+5)) // trim(cDet)
             headertext(2,position) = Labels(j+5)
@@ -244,7 +244,7 @@ module spreadsheet_header_routines
         end do
         ! back surface
         if (validate) then
-            do j = 2, 14
+            do j = 3, 15
                 if (j==3) cycle
                 position = position + 1
                 headertext(1,position) = trim(frontorback(2)) // trim(LabelsShort(j+5)) // trim(cDet)
@@ -269,8 +269,8 @@ module spreadsheet_header_routines
         end if
         do j = 1, 4
             position = position + 1
-            headertext(1,position) = trim(LabelsShort(j+19))//trim(cDet)
-            headertext(2,position) = Labels(j+19)
+            headertext(1,position) = trim(LabelsShort(j+20))//trim(cDet)
+            headertext(2,position) = Labels(j+20)
             write (cTemp,'(a,1x,a,1x,a)') trim(cType),'Sensor',trim(cDet)
             headertext(3,position) = cTemp
             headertext(4,position) = LabelUnits(j+19)

--- a/Source/CFAST/target.f90
+++ b/Source/CFAST/target.f90
@@ -22,6 +22,7 @@ module target_routines
     implicit none
 
     real(eb), dimension(2) :: qtcflux, qtfflux, qtwflux, qtgflux    ! temporary variables for target flux calculation
+    integer, parameter :: front=1, back=2                           ! subscripts for flux variables
 
     private
 
@@ -74,12 +75,16 @@ module target_routines
         end if
         ttarg(1) = targptr%temperature(idx_tempf_trg)
         ttarg(2) = targptr%temperature(idx_tempb_trg)
-        call target_flux(1,itarg,ttarg,flux,dflux)
-        call target_flux(2,itarg,ttarg,flux,dflux)
-        targptr%flux_front = qtwflux(1) + qtfflux(1) + qtcflux(1) + qtgflux(1)
-        targptr%flux_back = qtwflux(2) + qtfflux(2) + qtcflux(2) + qtgflux(2)
-        targptr%flux_net_front = flux(1)
-        targptr%flux_net_back = flux(2)
+        
+        call target_flux(front,itarg,ttarg,flux,dflux)
+        targptr%flux_incident_front = targptr%flux_surface(front) + targptr%flux_fire(front)+ targptr%flux_gas(front) + &
+            targptr%flux_convection(front)
+        targptr%flux_net_front = flux(front)
+        
+        call target_flux(back,itarg,ttarg,flux,dflux) 
+        targptr%flux_incident_back = targptr%flux_surface(back) + targptr%flux_fire(back) + targptr%flux_gas(back) + &
+            targptr%flux_convection(back)
+        targptr%flux_net_back = flux(back)
 
         ! do conduction into target
         wfluxin = targptr%flux_net_front
@@ -134,7 +139,6 @@ module target_routines
     real(eb) :: dttarg, dttargb, temis, q1, q2, q1b, q2b, q1g, dqdtarg, dqdtargb
     real(eb) :: target_factors_front(10), target_factors_back(10)
     integer :: map10(10) = (/1,3,3,3,3,4,4,4,4,2/), iroom, i, nfirerm, istart, ifire, iwall, iw, iwb
-    integer, parameter :: front=1, back=2
 
     type(room_type), pointer :: roomptr
     type(target_type), pointer :: targptr


### PR DESCRIPTION
…ent with output values (emissivity was not included). Should change typical ignition times by less than a few seconds. Added incident flux to printed and spreadsheet output.

Made ignition criteria checks consistent so that 1 = temp, 2 = temperature, and 3 = flux for all variables (before criteria type and criteria values were in different orders).