### PR TITLE
CFAST: Make wall vent opening/closing consistent with all other vent types.

### DIFF
--- a/Source/CFAST/cfast_data.f90
+++ b/Source/CFAST/cfast_data.f90
@@ -130,7 +130,6 @@ module ramp_data
 
     ! ramping variables
     integer :: nramps = 0
-    real(eb) :: qcvh(4,mxhvents)
     type(ramp_type), target :: rampinfo(mxramps)
 
 end module ramp_data

--- a/Source/CFAST/cfast_structures.f90
+++ b/Source/CFAST/cfast_structures.f90
@@ -261,6 +261,10 @@ module cfast_types
 
         ! These are common to more than one vent types
 
+        integer :: opening_target           ! target number associated with vent (user input)
+        integer :: opening_type             ! open/close type for fire (user input)
+                                            ! (1 = time, 2 = temperature, 3 = heat flux)
+        real(eb) :: opening_criterion       ! open/close criteria for fire. Units depend on ignition type (user input)
         real(eb), dimension(4) :: opening   ! simple open and closing of vents
                                             ! 1 = initial fraction of vent opening
                                             ! 2 = end time for initial open fraction

--- a/Source/CFAST/flowfan.f90
+++ b/Source/CFAST/flowfan.f90
@@ -2,7 +2,7 @@ module mflow_routines
 
     use precision_parameters
 
-    use opening_fractions, only : qcffraction, qcifraction, get_vent_opening
+    use opening_fractions, only : get_vent_opening
     use utility_routines, only: d1mach, tanhsmooth
 
     use precision_parameters

--- a/Source/CFAST/flowhorizontal.f90
+++ b/Source/CFAST/flowhorizontal.f90
@@ -2,7 +2,7 @@ module hflow_routines
 
     use precision_parameters
 
-    use opening_fractions, only: qchfraction
+    use opening_fractions, only: get_vent_opening
     use debug_routines, only: ssprintslab, spreadsheetfslabs
     use room_data
     use utility_routines, only: tanhsmooth
@@ -93,7 +93,7 @@ module hflow_routines
         !  use new interpolator to find vent opening fraction
         im = min(iroom1,iroom2)
         ix = max(iroom1,iroom2)
-        fraction = qchfraction (qcvh, i, tsec)
+        call get_vent_opening ('H',im,ix,ik,i,tsec,fraction)
         height = ventptr%soffit - ventptr%sill
         width = ventptr%width*fraction
         avent = height*width

--- a/Source/CFAST/initialization.f90
+++ b/Source/CFAST/initialization.f90
@@ -3,7 +3,6 @@ module initialization_routines
     use precision_parameters
 
     use numerics_routines, only: dnrm2, dscal
-    use opening_fractions, only : qchfraction
     use output_routines, only : deleteoutputfiles
     use solve_routines, only : update_data
     use utility_routines, only: indexi, xerror
@@ -315,11 +314,6 @@ module initialization_routines
     hventinfo(1:mxhvents)%opening(initial_fraction) = 0.0_eb
     hventinfo(1:mxhvents)%opening(final_time) = 1.0_eb
     hventinfo(1:mxhvents)%opening(final_fraction) = 0.0_eb
-    
-    qcvh(1,1:mxhvents) = 0.0_eb
-    qcvh(2,1:mxhvents) = 1.0_eb
-    qcvh(3,1:mxhvents) = 0.0_eb
-    qcvh(4,1:mxhvents) = 1.0_eb
 
     ! vertical vents
     vventinfo(1:mxvvents)%shape = 1

--- a/Source/CFAST/input.f90
+++ b/Source/CFAST/input.f90
@@ -913,8 +913,8 @@ module input_routines
                 stop
             end if
 
-            qcvh(2,n_hvents) = initialopening
-            qcvh(4,n_hvents) = initialopening
+            ventptr%opening(initial_fraction) = initialopening
+            ventptr%opening(final_fraction) = initialopening
 
             roomptr => roominfo(ventptr%room1)
             ventptr%absolute_soffit = ventptr%soffit + roomptr%z0
@@ -954,15 +954,15 @@ module input_routines
                     do iijk = 1, n_hvents
                         ventptr => hventinfo(iijk)
                         if (ventptr%room1==i.and.ventptr%room2==j.and.ventptr%counter==k) then
-                            qcvh(1,iijk) = lrarray(5)
-                            qcvh(3,iijk) = lrarray(5) + lrarray(7)
-                            qcvh(4,iijk) = lrarray(6)
+                            ventptr%opening(initial_time) = lrarray(5)
+                            ventptr%opening(final_time) = lrarray(5) + lrarray(7)
+                            ventptr%opening(final_fraction) = lrarray(6)
                         end if
                     end do
                 case ('V')
                     i = lrarray(2)
                     j = lrarray(3)
-                    k = 1
+                    k = lrarray(4)
                     do iijk = 1, n_vvents
                         ventptr => vventinfo(iijk)
                         if (ventptr%top==i.and.ventptr%bottom==j.and.ventptr%counter==k) then
@@ -974,7 +974,7 @@ module input_routines
                 case ('M')
                     i = lrarray(2)
                     j = lrarray(3)
-                    k = 1
+                    k = lrarray(4)
                     do iijk = 1, n_mvents
                         ventptr => mventinfo(iijk)
                         if (ventptr%room1==i.and.ventptr%room2==j.and.ventptr%counter==k) then

--- a/Source/CFAST/outputspreadsheet.f90
+++ b/Source/CFAST/outputspreadsheet.f90
@@ -4,7 +4,7 @@ module spreadsheet_routines
 
     use fire_routines, only : flame_height
     use target_routines, only: get_target_temperatures
-    use opening_fractions, only : qchfraction
+    use opening_fractions, only : get_vent_opening
     use spreadsheet_header_routines
     use utility_routines, only: ssaddtolist
 
@@ -514,7 +514,7 @@ module spreadsheet_routines
         ik = ventptr%counter
         im = min(iroom1,iroom2)
         ix = max(iroom1,iroom2)
-        fraction = qchfraction (qcvh,i,time)
+        call get_vent_opening ('H',im,ix,ik,i,time,fraction)
         height = ventptr%soffit - ventptr%sill
         width = ventptr%width
         avent = fraction*height*width

--- a/Source/CFAST/solve.f90
+++ b/Source/CFAST/solve.f90
@@ -10,7 +10,7 @@ module solve_routines
     use hflow_routines, only: horizontal_flow
     use mflow_routines, only: mechanical_flow
     use numerics_routines, only : ddassl, jac, setderv, snsqe, gjac
-    use opening_fractions, only : qchfraction
+    use opening_fractions, only : get_vent_opening
     use output_routines, only: output_results, output_status, output_debug, deleteoutputfiles, find_error_component
     use radiation_routines, only: radiation
     use smokeview_routines, only: output_smokeview, output_smokeview_header, output_smokeview_plot_data, output_slicedata
@@ -160,7 +160,7 @@ module solve_routines
         ik = ventptr%counter
         im = min(iroom1,iroom2)
         ix = max(iroom1,iroom2)
-        fraction = qchfraction(qcvh,i,tsec)
+        call get_vent_opening ('H',im,ix,ik,i,tsec,fraction)
         height = ventptr%soffit - ventptr%sill
         width = ventptr%width
         avent = fraction*height*width
@@ -1373,10 +1373,11 @@ module solve_routines
 
         ! add each of the change arrays to the discontinuity list
         do  i = 1, n_hvents
+            ventptr => hventinfo(i)
             ndisc = ndisc + 1
-            discon(ndisc) = qcvh(1,i)
+            discon(ndisc) = ventptr%opening(1)
             ndisc = ndisc + 1
-            discon(ndisc) = qcvh(3,i)
+            discon(ndisc) = ventptr%opening(3)
         end do
         do  i = 1, n_vvents
             ventptr => vventinfo(i)


### PR DESCRIPTION
Now they all use the same code and data structure for opening and closing. RAMP keyword that allows multiple opening and closing should work too.