### PR TITLE
cfast vv: remove -v from runcfast.bat script

### DIFF
--- a/Validation/scripts/Run_CFAST_Cases.bat
+++ b/Validation/scripts/Run_CFAST_Cases.bat
@@ -4,6 +4,10 @@ set rundebug=%1
 set bgexe=%2
 set SH2BAT=%3
 
+if "%bgexe%" == "" (
+  set bgexe=background.exe
+)
+
 if "%SH2BAT%" == "" (
   set SH2BAT=sh2bat.exe
 )

--- a/Validation/scripts/runcfast.bat
+++ b/Validation/scripts/runcfast.bat
@@ -11,4 +11,4 @@ set stopfile=%infile%.stop
 
 cd %fulldir%
 echo %in% started
-%CFAST% %in%  1> %out% 2>&1 -V
+%CFAST% %in%  1> %out% 2>&1


### PR DESCRIPTION
rick,
this -v option in the runcfast.bat script was keeping cfast from running - the background program was using it.  does cfast need the -v option for cfastbot ?
glenn