### PR TITLE
Fix for Issue #754. Update NIST Vent Study input files.

### DIFF
--- a/Validation/NIST_Vent_Study/Test_1.in
+++ b/Validation/NIST_Vent_Study/Test_1.in
@@ -9,11 +9,12 @@ TAMB,293.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_10.in
+++ b/Validation/NIST_Vent_Study/Test_10.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_11.in
+++ b/Validation/NIST_Vent_Study/Test_11.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_12.in
+++ b/Validation/NIST_Vent_Study/Test_12.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_13.in
+++ b/Validation/NIST_Vent_Study/Test_13.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_14.in
+++ b/Validation/NIST_Vent_Study/Test_14.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_15.in
+++ b/Validation/NIST_Vent_Study/Test_15.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_2.in
+++ b/Validation/NIST_Vent_Study/Test_2.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_3.in
+++ b/Validation/NIST_Vent_Study/Test_3.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_4.in
+++ b/Validation/NIST_Vent_Study/Test_4.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_5.in
+++ b/Validation/NIST_Vent_Study/Test_5.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_6.in
+++ b/Validation/NIST_Vent_Study/Test_6.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_7.in
+++ b/Validation/NIST_Vent_Study/Test_7.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_8.in
+++ b/Validation/NIST_Vent_Study/Test_8.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!

--- a/Validation/NIST_Vent_Study/Test_9.in
+++ b/Validation/NIST_Vent_Study/Test_9.in
@@ -9,11 +9,12 @@ TAMB,291.15,101325,0,50
 !!Material Properties
 !!
 MATL,Gypboard,0.16,1000,480,0.015875,0.9,Gypsum Board
+MATL,Thingyp,0.16,1000,480,0.0079375,0.9,Thin Gypsum Board
 !!
 !!Compartments
 !!
-COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Gypboard,Gypboard,Gypboard,50,50,50
-COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Gypboard,Gypboard,Gypboard,50,50,50
+COMPA,Comp 1,1.1938,1.2192,0.587375,0,0,0,Thingyp,Gypboard,Gypboard,50,50,50
+COMPA,Comp 2,1.1938,1.2192,0.6096,0,0,0.587375,Thingyp,Gypboard,Gypboard,50,50,50
 !!
 !!Vents
 !!


### PR DESCRIPTION
V&V: Change thickness of NIST Vent Study Floor/Ceiling to match single layer between compartments. Model Bias for the test series improves by 1 %. Change to overall V&V is in the noise.