### PR TITLE
cfast build: change optimization level to -O0 for linux build - (temp…

### DIFF
--- a/Build/CFAST/makefile
+++ b/Build/CFAST/makefile
@@ -135,7 +135,7 @@ gnu_linux_64_db : $(objfgnu)
 	$(FCOMPL) $(FFLAGS) -o $(obj) $(objfgnu)
 
 # 64 bit
-intel_linux_64 : FFLAGS = -m64 -O2 -save -zero -static -gen-interfaces -warn interfaces -traceback $(GITINFO)
+intel_linux_64 : FFLAGS = -m64 -O0 -save -zero -static -gen-interfaces -warn interfaces -traceback $(GITINFO)
 intel_linux_64 : LFLAGS = -static-intel
 intel_linux_64 : FCOMPL = ifort
 intel_linux_64 : obj = cfast7_linux_64


### PR DESCRIPTION
…orary)