### PR TITLE
Include non-integer values for all output interval

### DIFF
--- a/Source/CFAST/cfast_data.f90
+++ b/Source/CFAST/cfast_data.f90
@@ -223,7 +223,8 @@ module setup_data
     implicit none
     save
     
-    integer :: ss_out_interval, print_out_interval, smv_out_interval, time_end, i_time_end, i_time_step
+    integer :: i_time_end, i_time_step
+    real(eb) :: ss_out_interval, print_out_interval, smv_out_interval, time_end
     real(eb) :: stime, deltat
 
     character(128) :: title

--- a/Source/CFAST/cfast_parameters.f90
+++ b/Source/CFAST/cfast_parameters.f90
@@ -139,10 +139,10 @@
     integer, parameter :: default_version = 0
 
     ! time-related default values
-    integer, parameter :: default_simulation_time = 900
-    integer, parameter :: default_print_out_interval = 60
-    integer, parameter :: default_smv_out_interval = 15
-    integer, parameter :: default_ss_out_interval = 15
+    real(eb), parameter :: default_simulation_time = 900._eb
+    real(eb), parameter :: default_print_out_interval = 60._eb
+    real(eb), parameter :: default_smv_out_interval = 15._eb
+    real(eb), parameter :: default_ss_out_interval = 15._eb
 
     ! ambient condition default values
     real(eb), parameter :: default_temperature = 293.15_eb

--- a/Source/CFAST/input_namelist.f90
+++ b/Source/CFAST/input_namelist.f90
@@ -141,7 +141,7 @@
     integer :: ios
     integer, intent(in) :: lu
 
-    integer :: simulation,print,spreadsheet,smokeview
+    real(eb) :: simulation,print,spreadsheet,smokeview
     namelist /TIME/ print,simulation,spreadsheet,smokeview
 
     ios = 1

--- a/Source/CFAST/output.f90
+++ b/Source/CFAST/output.f90
@@ -618,7 +618,7 @@ module output_routines
 5010 FORMAT (/,'Compartments    Doors, ...    Ceil. Vents, ...    MV Connects',/,61('-'),/,i4,12x,i4,10x,i4,17x,i4)
 5020 format (/,'Simulation     Output         Smokeview      Spreadsheet',/, &
              'Time           Interval       Interval       Interval',/, &
-             '   (s)            (s)            (s)            (s)',/,56('-'),/,i6,6x,3(i6,9x))
+             '   (s)            (s)            (s)            (s)',/,56('-'),/,4(e10.5,5x))
     end subroutine output_initial_overview
 
 ! --------------------------- output_initial_ambient_conditions -------------------------------------------


### PR DESCRIPTION
Minor changes to enable the use of non-integer values for output intervals

