### PR TITLE
Updates for calculation of surface opening fraction

### DIFF
--- a/Source/CFAST/cfast_structures.f90
+++ b/Source/CFAST/cfast_structures.f90
@@ -154,6 +154,7 @@ module cfast_types
                                                         !   2 = only user specified vents
         integer, dimension(mxrooms) :: hheat_connections! list of connected compartments for horizontal heat transfer
         real(eb), dimension(mxrooms) :: heat_frac       ! fractions of wall surface of this room connected to other rooms in list
+        real(eb), dimension(10) :: chi                  ! surface opening ratio of a particular surface based on 10-wall model
 
 
         ! These are calculated results for the current time step

--- a/Source/CFAST/initialization.f90
+++ b/Source/CFAST/initialization.f90
@@ -289,6 +289,9 @@ module initialization_routines
         roomptr%iheat = 0
         roomptr%hheat_connections(1:mxrooms) = 0
         roomptr%heat_frac(1:mxrooms) = 0
+        
+        !initialize surface opening fraction
+        roomptr%chi(1:10) = 0._eb
     end do
 
     ! initialize number of furnace temperature nodes

--- a/Source/CFAST/solve.f90
+++ b/Source/CFAST/solve.f90
@@ -18,7 +18,7 @@ module solve_routines
     use target_routines, only: target, update_detectors, get_detector_temp_and_velocity
     use utility_routines, only: mat2mult, interp, shellsort, cptime, xerror, funit
     use vflow_routines, only: vertical_flow
-    use compartment_routines, only: layer_mixing, synchronize_species_mass, room_connections
+    use compartment_routines, only: layer_mixing, synchronize_species_mass, room_connections, wall_opening_fraction
 
     use cenviro
     use ramp_data
@@ -921,6 +921,9 @@ module solve_routines
     ! calculate heat and mass flows due to fires
     call fire (tsec,flows_fires)
     call door_jet (flows_doorjets,djetflg)
+    
+    ! calculation opening fraction for radiation loss and etc
+    call wall_opening_fraction (tsec)
 
     ! calculate flow and flux due to heat transfer (ceiling jets, convection and radiation)
     call convection (flows_convection,fluxes_convection)


### PR DESCRIPTION
A subroutine, wall_opening_fraction, is added to the compartment module. 

The subroutine is used to calculate a new variable, CHI, and that is, the ratio of opening area due to any existence of vents to the total area of that particular surface. 

This subroutine is called in solve.f and the variable, CHI, can then be used in convection.f and radiation.f. Note that CHI is not being used in convection.f and radiation.f yet.

A verification case for calculation of CHI and updates to the guides will be uploaded in next PR. Screenshot of the verification case is attached for reference.

![example](https://user-images.githubusercontent.com/23366519/41109605-6034cf7a-6a45-11e8-8c66-961d901c4ad6.jpg)

. 