### PR TITLE
Update for radiation solver and fix for non-integer run

### DIFF
--- a/Source/CFAST/cfast.f90
+++ b/Source/CFAST/cfast.f90
@@ -66,10 +66,10 @@
 
     call initialize_species
 
-    i_time_step = 1
+    i_time_step = 1._eb
     xdelt = time_end/deltat
-    i_time_end = xdelt + 1
-    tstop = i_time_end - 1
+    i_time_end = xdelt + 1._eb
+    tstop = i_time_end - 1._eb
 
     ! add the default thermal property
     n_thrmp = n_thrmp + 1

--- a/Source/CFAST/cfast_data.f90
+++ b/Source/CFAST/cfast_data.f90
@@ -34,17 +34,19 @@ module  diag_data
     
     ! Verification flag
     logical :: radi_verification_flag = .false.
-    real(eb) :: verification_time_step = 0._eb
+    real(eb) :: verification_time_step = -1001._eb
     ! Diagnostic variables for radiative properties
-    real(eb) :: partial_pressure_h2o, partial_pressure_co2, gas_temperature
+    real(eb) :: partial_pressure_h2o = -1001._eb, partial_pressure_co2 = -1001._eb, &
+                gas_temperature = -1001._eb
     ! Diagnostic veriables for radiation solver
     character(64) :: rad_solver
     logical :: radi_radnnet_flag = .false.
+    real(eb), dimension(4) :: temperature_wall = -1001._eb, emissivity_wall = 1._eb
     ! Diagnostic variables for adiabatic target surface temperature
     logical :: verification_ast=.false.
     real(eb) :: radiative_incident_flux_AST = 0._eb
     ! Diagnostic variable for surface opening fraction
-    real(eb) :: upper_layer_thickness = 0._eb
+    real(eb) :: upper_layer_thickness = -1001._eb
 
 end module diag_data
 
@@ -229,7 +231,7 @@ module setup_data
     implicit none
     save
     
-    integer :: i_time_end, i_time_step
+    real(eb) :: i_time_end, i_time_step
     real(eb) :: ss_out_interval, print_out_interval, smv_out_interval, time_end
     real(eb) :: stime, deltat
 

--- a/Source/CFAST/cfast_structures.f90
+++ b/Source/CFAST/cfast_structures.f90
@@ -154,9 +154,12 @@ module cfast_types
                                                         !   2 = only user specified vents
         integer, dimension(mxrooms) :: hheat_connections! list of connected compartments for horizontal heat transfer
         real(eb), dimension(mxrooms) :: heat_frac       ! fractions of wall surface of this room connected to other rooms in list
-        real(eb), dimension(10) :: chi                  ! surface opening ratio of a particular surface based on 10-wall model
         integer, dimension(mxrooms) :: room_connections ! list of connected compartments, number of compartments to travel through
                                                         ! to get to each compartment from the current compartment
+        real(eb), dimension(4)  :: chi4                 ! surface opening ratio of a particular surface for 4-wall model
+        real(eb), dimension(10) :: chi10                ! surface opening ratio of a particular surface for 10-wall model
+        real(eb), dimension(4)  :: total_surface_opening4  ! total opening area for a particular surface for 4-wall model
+        real(eb), dimension(10) :: total_surface_opening10 ! total opening area for a particular surface for 10-wall model
 
 
         ! These are calculated results for the current time step

--- a/Source/CFAST/convection.f90
+++ b/Source/CFAST/convection.f90
@@ -55,7 +55,11 @@
         end if
         ! assume no fires in this room.  just use regular convection
         call convective_flux(iwall,roomptr%temp(ilay),roomptr%t_surfaces(1,iwall),fluxes_convection(i,iwall))
-        w_area = roomptr%wall_area4(iwall)
+        if (nrm1 == 1 .and. sum(roomptr%chi4(:)) /= 0._eb) then 
+            w_area = roomptr%wall_area4(iwall)*(1._eb - roomptr%chi4(iwall))
+        else
+            w_area = roomptr%wall_area4(iwall)
+        end if
         ! if there's a fire, we may need to modify the convection to account for the ceiling jet
         if (iwall==1.and.n_fires>0) then
             qconv = 0.0_eb

--- a/Source/CFAST/initialization.f90
+++ b/Source/CFAST/initialization.f90
@@ -293,8 +293,11 @@ module initialization_routines
         roomptr%hheat_connections(1:mxrooms) = 0
         roomptr%heat_frac(1:mxrooms) = 0
         
-        !initialize surface opening fraction
-        roomptr%chi(1:10) = 0._eb
+        !initialize surface opening fraction parameters
+        roomptr%chi4(1:4) = 0._eb
+        roomptr%chi10(1:10) = 0._eb
+        roomptr%total_surface_opening4(1:4) = 0._eb
+        roomptr%total_surface_opening10(1:10) = 0._eb
     end do
 
     ! initialize number of furnace temperature nodes

--- a/Source/CFAST/input_namelist.f90
+++ b/Source/CFAST/input_namelist.f90
@@ -2507,7 +2507,7 @@ continue
                     conduction_sub_model, debug_print, mechanical_flow_sub_model, keyboard_input, &
                     steady_state_initial_conditions, dassl_debug_print, oxygen_tracking, gas_absorbtion_sub_model, &
                     residual_debug_print, layer_mixing_sub_model, adiabatic_target_verification, radiative_incident_flux, &
-                    upper_layer_thickness, verification_time_step
+                    upper_layer_thickness, verification_time_step, temperature_wall, emissivity_wall
 
     ios = 1
 
@@ -2651,7 +2651,9 @@ continue
     adiabatic_target_verification   = 'OFF'
     radiative_incident_flux         = 0._eb
     upper_layer_thickness           = -1001._eb
-    verification_time_step          = 0._eb
+    verification_time_step          = -1001._eb
+    temperature_wall(:)             = -1001._eb  ! notation ceiling, upper, lower, and floor
+    emissivity_wall(:)              = 1._eb
 
     end subroutine set_defaults
 

--- a/Source/CFAST/outputsmv.f90
+++ b/Source/CFAST/outputsmv.f90
@@ -51,8 +51,8 @@
     !  froom_number - room containing fire
     !  fx0,fy0,fz0 - location of fire base
 
-    real(eb), intent(in) :: pabs_ref, pamb, tamb, stime
-    integer, intent(in) :: nrm, nscount, n_hvents, nfires, n_vvents, n_targets
+    real(eb), intent(in) :: pabs_ref, pamb, tamb, stime, nscount
+    integer, intent(in) :: nrm, n_hvents, nfires, n_vvents, n_targets
     integer, intent(in), dimension(nfires) :: froom_number
     real(eb), intent(in), dimension(nfires) :: fx0, fy0, fz0
 
@@ -220,7 +220,7 @@
     end do
 
     write (13,"(a)") "TIME"
-    write (13,"(1x,i6,1x,f11.0)") nscount, stime
+    write (13,"(1x,f11.0,1x,f11.0)") nscount, stime
 
     ! zone model devices
     call ssheaders_smv(.false.)

--- a/Source/CFAST/outputspreadsheet.f90
+++ b/Source/CFAST/outputspreadsheet.f90
@@ -671,7 +671,7 @@ module spreadsheet_routines
     do i = 1, nrm1
         roomptr => roominfo(i)
         do j = 1, 10
-            call ssaddtolist (position,roomptr%chi(j),outarray)
+            call ssaddtolist (position,roomptr%chi10(j),outarray)
         end do
     end do
 


### PR DESCRIPTION
Radiation solver update to account for radiation loss

This pull request includes:
1)	A new 10-wall radiation model (rad10), its associated subroutines (rad10_initalization, ten_view_factors, ten_beam, rdfang10, rdflux10, rabs10) and a function (rdprpfig) added to calculate the view factor between two perpendicular plates with a common edge
2)	Verification variables to check the energy balance for gas, wall, and fire emission are introduced to rad10. (Verification cases are generated and results show that all emission terms are conserved. The verification cases and updated documentations will be provided in the next PR.)
3)	New Diag variables are added
4)	Minor updates for a number of subroutines to facilitate the changes

For now, rad10 is limited to one room application if there are openings. This restriction will be removed in the next update to rad10.

Cfastbot is ran and everything works well.
