### PR TITLE
CFAST: Add option to specify internal target temperature location as an actual depth rather than as a fraction of the thickness of the target.

### DIFF
--- a/Source/CFAST/cfast_structures.f90
+++ b/Source/CFAST/cfast_structures.f90
@@ -220,6 +220,8 @@ module cfast_types
     type target_type
         character(64) :: name           ! user selected name for the target
         character(64) :: material       ! material for the target (used to match materials properties)
+        character(64) :: depth_units    ! specify units for temperature depth location, 'FRACTION' or 'M'
+                                        ! default is 'FRACTION' for backwards compatibility
 
         real(eb) :: center(3)           ! position of target center
         real(eb) :: normal(3)           ! target normal vector

--- a/Source/CFAST/initialization.f90
+++ b/Source/CFAST/initialization.f90
@@ -664,7 +664,11 @@ module initialization_routines
         targptr%c = thrmpptr%c(1)
         targptr%rho = thrmpptr%rho(1)
         targptr%thickness = thrmpptr%thickness(1)
-        targptr%depth_loc = max(0.0_eb,min(targptr%thickness*targptr%depth_loc,targptr%thickness))
+        if (targptr%depth_units=='FRACTION') then
+            targptr%depth_loc = max(0.0_eb,min(targptr%thickness*targptr%depth_loc,targptr%thickness))
+        else
+            targptr%depth_loc = max(0.0_eb,min(targptr%depth_loc,targptr%thickness))
+        end if
         targptr%emissivity = thrmpptr%eps
     end do
 

--- a/Source/CFAST/input_namelist.f90
+++ b/Source/CFAST/input_namelist.f90
@@ -583,12 +583,11 @@
     real(eb) :: temperature_depth,rti,setpoint,spray_density
     real(eb),dimension(3) :: location,normal
     real(eb),dimension(2) :: setpoints
-    character(64) :: comp_id,id,matl_id
-    character(64) :: type
+    character(64) :: comp_id, id, matl_id, type, depth_units
     logical :: adiabatic_target
     real(eb), dimension(2) :: convection_coefficients
-    namelist /DEVC/ comp_id, type, id, temperature_depth, location, matl_id, normal, rti, setpoint, spray_density, setpoints, &
-                    adiabatic_target, convection_coefficients
+    namelist /DEVC/ comp_id, type, id, temperature_depth, depth_units, location, matl_id, normal, rti, setpoint, &
+        spray_density, setpoints, adiabatic_target, convection_coefficients
 
     ios = 1
 
@@ -678,6 +677,7 @@
                 targptr%normal = normal
 
                 targptr%depth_loc = temperature_depth
+                targptr%depth_units = depth_units
 
                 ! target name
                 targptr%name = id
@@ -828,6 +828,7 @@
     type                            = 'NULL'
     id                              = 'NULL'
     temperature_depth               = 0.5_eb
+    depth_units                     = 'FRACTION'
     location(:)                     = (/-1.0_eb, -1.0_eb, -3.0_eb/39.37_eb/)
     matl_id                         = 'NULL'
     normal(:)                       = (/0., 0., 1./)


### PR DESCRIPTION
Addresses Issue #1287

Still need to add support for it in CEdit. 