### PR TITLE
Revert "CFAST: Bug fix removed renorm in Init_ambient"

### DIFF
--- a/Source/CFAST/cfast_structures.f90
+++ b/Source/CFAST/cfast_structures.f90
@@ -156,7 +156,6 @@ module cfast_types
         real(eb) :: wall_center(3,10)                   ! coordinates of center of each surface in compartment
         real(eb) :: interior_relp_initial               ! initial value of interior pressure relative to minimum pressure
         real(eb) :: exterior_relp_initial               ! initial value of exterior pressure relative to minimum pressure
-        real(eb) :: exterior_den_initial                ! initial value for exterior density at base of compartment
         logical :: is_connection                        ! true if there is a natural flow vent connection in the room that
                                                         ! connects to the outside (perhaps through other intermediate rooms)
         logical :: is_hvac                              ! true if there is an HVAC vent connection in the room

--- a/Source/CFAST/flowvertical.f90
+++ b/Source/CFAST/flowvertical.f90
@@ -7,11 +7,10 @@ module vflow_routines
     
     use cfast_types, only: room_type, vent_type
     
-    use cenviro, only: cp, rgas
+    use cenviro, only: cp
     use cparams, only: u, l, m, q, deltatemp_min, pp, mxrooms
     use option_data, only: fvflow, option, on
-    use room_data, only: n_rooms, ns, roominfo, exterior_ambient_temperature, interior_ambient_temperature, exterior_rho, &
-                        exterior_abs_pressure
+    use room_data, only: n_rooms, ns, roominfo, exterior_ambient_temperature, interior_ambient_temperature, exterior_rho
     use vent_data, only: n_vvents, vventinfo
 
     implicit none
@@ -229,7 +228,7 @@ module vflow_routines
         dp(1) = 0.0_eb
         relp(1) = toproomptr%relp
     else
-        dp(1) = -grav_con*botroomptr%cheight*botroomptr%exterior_den_initial
+        dp(1) = -grav_con*botroomptr%cheight*exterior_rho
         relp(1) = botroomptr%exterior_relp_initial
     end if
 
@@ -258,13 +257,12 @@ module vflow_routines
     if (itop<=n_rooms) then
         den(1) = toproomptr%rho(ilay(1))
     else
-        den(1) = botroomptr%exterior_relp_initial-grav_con*botroomptr%cheight*botroomptr%exterior_den_initial
-        den(1) = (exterior_abs_pressure - den(1))/rgas/exterior_ambient_temperature
+        den(1) = exterior_rho
     end if
     if (ibot<=n_rooms) then
         den(2) = botroomptr%rho(ilay(2))
     else
-        den(2) = toproomptr%exterior_den_initial
+        den(2) = exterior_rho
     end if
     delden = den(1) - den(2)
 

--- a/Source/CFAST/initialization.f90
+++ b/Source/CFAST/initialization.f90
@@ -9,7 +9,7 @@ module initialization_routines
 
     use cfast_types, only: detector_type, fire_type, room_type, target_type, material_type, vent_type
 
-    use cenviro, only: constvar, odevara, rgas
+    use cenviro, only: constvar, odevara
     use cparams, only: u, l, mxrooms, mxthrmplen, mxmatl, mxhvents, mxvvents, mxmvents, mxleaks, &
         mxdtect, mxtarg, mxslb, mx_vsep, mxtabls, mxfires, pde, interior, nwal, idx_tempf_trg, idx_tempb_trg, &
         xlrg, default_grid, face_front, trigger_by_time, h2o, ns_mass, w_from_room, w_to_room, w_from_wall, w_to_wall, &
@@ -94,32 +94,26 @@ module initialization_routines
         roomptr => roominfo(i)
         roomptr%interior_relp_initial = -interior_rho*grav_con*roomptr%z0
         roomptr%exterior_relp_initial = -exterior_rho*grav_con*roomptr%z0
-        roomptr%exterior_den_initial = (exterior_abs_pressure +                         &
-            roomptr%exterior_relp_initial)/rgas/exterior_ambient_temperature     
     end do
     roomptr => roominfo(n_rooms+1)
     roomptr%exterior_relp_initial = 0.0_eb
 
-    
-    !! normalize pressures so that the smallest pressure is zero
-    !roomptr => roominfo(1)
-    !xxpmin = min(roomptr%interior_relp_initial,roomptr%exterior_relp_initial)
-    !do i = 2, n_rooms
-    !    roomptr => roominfo(i)
-    !    xxpmin = min(xxpmin,roomptr%interior_relp_initial,roomptr%exterior_relp_initial)
-    !end do
-    !pressure_offset = pressure_offset + xxpmin
-    !!interior_abs_pressure = interior_abs_pressure - pressure_offset
-    !!exterior_abs_pressure = exterior_abs_pressure - pressure_offset
-    !interior_abs_pressure = interior_abs_pressure + xxpmin
-    !exterior_abs_pressure = exterior_abs_pressure + xxpmin
-    !do i = 1, n_rooms
-    !    roomptr => roominfo(i)
-    !    roomptr%interior_relp_initial = roomptr%interior_relp_initial - xxpmin
-    !    roomptr%exterior_relp_initial = roomptr%exterior_relp_initial - xxpmin
-    !    roomptr%exterior_den_initial = (exterior_abs_pressure +                         &
-    !        roomptr%exterior_relp_initial)/rgas/exterior_ambient_temperature            
-    !end do
+
+    ! normalize pressures so that the smallest pressure is zero
+    roomptr => roominfo(1)
+    xxpmin = min(roomptr%interior_relp_initial,roomptr%exterior_relp_initial)
+    do i = 2, n_rooms
+        roomptr => roominfo(i)
+        xxpmin = min(xxpmin,roomptr%interior_relp_initial,roomptr%exterior_relp_initial)
+    end do
+    do i = 1, n_rooms
+        roomptr => roominfo(i)
+        roomptr%interior_relp_initial = roomptr%interior_relp_initial - xxpmin
+        roomptr%exterior_relp_initial = roomptr%exterior_relp_initial - xxpmin
+    end do
+    pressure_offset = pressure_offset + xxpmin
+    interior_abs_pressure = interior_abs_pressure - pressure_offset
+    exterior_abs_pressure = exterior_abs_pressure - pressure_offset
 
     ! copy all of the variables from the initial values into the data arrays
     call update_data (dummy,constvar)

--- a/Source/CFAST/input_namelist.f90
+++ b/Source/CFAST/input_namelist.f90
@@ -1999,7 +1999,7 @@ continue
     else
         write (errormessage,'(4a,i0)') '***Error, Inputs for wall vent: criterion has to be "TIME", "TEMPERATURE", or "FLUX".', &
             ' for vent ',trim(id), ' &VENT number ', counter1 + counter2 + counter3
-        call cfastexit('read_vent:set_criterion',1)
+        call cfastexit('read_vent_set_criterion',2)
     end if
     
     end subroutine set_criterion
@@ -2029,7 +2029,6 @@ continue
         if (iroom == -101) then
             write (errormessage,'(5a,i0)') '***Error, COMP_IDS do not specify existing compartments. ', comp_ids(mm), &
                 ' for vent ',trim(id), ' &VENT number ', counter1 + counter2 + counter3
-            call cfastexit('read_vent:find_comp_idxes',1)
         end if
 
         if (mm == 1) i = iroom


### PR DESCRIPTION
This reverts commit 41856baaa68ec124a3f12913aac540ed5e56f7e6.