### PR TITLE
CFAST: Adjust radiation to lower layer when lower layer reaches minimum volume

### DIFF
--- a/Source/CFAST/cfast_parameters.f90
+++ b/Source/CFAST/cfast_parameters.f90
@@ -6,9 +6,6 @@
     use precision_parameters
 
     integer, parameter :: lbufln=1024           ! default line length for all inputs
-    
-    integer, parameter :: radiation_fix = 1     ! keep layer from dropping below 0.1 m when computing radiation
-                                                ! in that layer                                                
 
     ! geometry parameters
     integer, parameter :: mxrooms = 101         ! maximum number of compartments
@@ -72,6 +69,7 @@
     ! room related parameters
     real(eb), parameter :: cjetvelocitymin = 0.1_eb ! default minimum ceiling jet velocity
     real(eb), parameter :: vminfrac = 1.0e-4_eb     ! minimum layer volume as a fraction of room volume
+    integer, parameter :: radiation_fix = 1         ! adjust radiation calculation when layer reaches minimum volume 
 
     real(eb), parameter :: mx_vsep=0.01_eb          ! maximum vertical distance between elements before they are considered
                                                     ! separate elements (connected compartments for example)

--- a/Source/CFAST/radiation.f90
+++ b/Source/CFAST/radiation.f90
@@ -7,7 +7,7 @@ module radiation_routines
 
     use cfast_types, only: fire_type, room_type
 
-    use cparams, only: u, l, mxrooms, nwal, mxfires, co2, h2o, soot, radiation_fix
+    use cparams, only: u, l, mxrooms, nwal, mxfires, co2, h2o, soot, radiation_fix, vminfrac
     use fire_data, only: n_fires, fireinfo
     use option_data, only: frad, fgasabsorb, option, on, off
     use room_data, only: n_rooms, roominfo
@@ -153,13 +153,14 @@ module radiation_routines
 
     data iflag /mxroom*0/
 
-    ! this correction turns off radiation to the lower layer when the lower layer < 0.1 m
+    ! this correction turns off radiation to the lower layer when the lower layer reaches minimum volume
     hlay = hlay_arg
     factor_l = 1.0_eb
-    if (radiation_fix == 1 .and. hlay_arg<zroom/5000.0_eb) then
-      hlay = zroom/5000.0_eb
+    if (radiation_fix == 1 .and. hlay_arg/zroom<=vminfrac) then
+      hlay = vminfrac/zroom
       factor_l = 0.0_eb
     endif
+    
     if (iflag(iroom)==0) then
         f14(iroom) = rdparfig(xroom,yroom,zroom)
         iflag(iroom) = 1


### PR DESCRIPTION
Revised correction to be consistent with default definition of minimum layer volume already in the model. Overall, V&V is 0.2 % more accurate with no quantities showing large changes from previous accepted V&V stats.