### PR TITLE
CFAST Source: fix -O2 optimization flag for gnu_win build

### DIFF
--- a/Build/CFAST/makefile
+++ b/Build/CFAST/makefile
@@ -74,7 +74,7 @@ setup_win:
 # ------------- Windows -------------------
 
 # gnu windows
-gnu_win : FFLAGS = -O2 -finit-local-zero -ffpe-trap=invalid,zero,overflow -fbacktrace $(GITINFOGNU) $(PREPROCESS)
+gnu_win : FFLAGS = -O0 -finit-local-zero -ffpe-trap=invalid,zero,overflow -fbacktrace $(GITINFOGNU) $(PREPROCESS)
 gnu_win : FCOMPL = gfortran
 gnu_win : LFLAGS = 
 gnu_win : obj = cfast7_win


### PR DESCRIPTION
Hi,

Adressing issue #2231 

Change optimizaton flag from -O2 to -O0 in gnu_win Makefile.

Some `IEEE_UNDERFLOW_FLAG `warnings remain with `-O0` on certain verification cases but all simulations finish.

```
PS C:\Users\Benoit\cfast\cfast\Verification> .\runall.bat

C:\Users\Benoit\cfast\cfast\Verification>echo off
The current time is: 11:00:55.19
Enter the new time:
Running CFAST Verification Cases
Removing old and temporary files.  Messages can be ignored here.
The system cannot find the path specified.
Done removing old and temporary files.
Running Energy Balance cases
Running Mass Balance cases
Running Species cases
Note: The following floating-point exceptions are signalling: IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
Running Thermal Equilibrium cases
Running Ventilation cases
Running Sprinkler cases
Running Target and Radiation cases
Note: The following floating-point exceptions are signalling: IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
Running Fire Cases
Waiting for all CFAST runs to finish
Note: The following floating-point exceptions are signalling: IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
Note: The following floating-point exceptions are signalling: IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
Number of cases running - 11
Note: The following floating-point exceptions are signalling: IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
Number of cases running - 0
The current time is: 11:01:43.39
Enter the new time:
CFAST simulations complete
PS C:\Users\Benoit\cfast\cfast\Verification>
```