### PR TITLE
CFAST Source: Add compiler version to the output header

### DIFF
--- a/Source/CFAST/output.f90
+++ b/Source/CFAST/output.f90
@@ -30,6 +30,7 @@ module output_routines
     use material_data, only: n_matl, material_info
     use vent_data, only: n_hvents, hventinfo, n_vvents, vventinfo, n_mvents, mventinfo, n_leaks, leakinfo
     use dump_data, only: n_dumps, dumpinfo, iocsv, iocsv_walls, iocsv_compartments, iocsv_vents, iocsv_masses, iocsv_devices
+    use iso_fortran_env, only: compiler_version
 
     implicit none
     external grabky, get_info
@@ -70,6 +71,7 @@ module output_routines
     write (iunit,'(a,1x,a,1x,i0,".",i0,".",i0)')     TRIM(VERSION_PP),program_name,imajor, iminor, iminorrev
     write (iunit,'(A,A)')                    'Revision         : ',TRIM(revision)
     write (iunit,'(A,A)')                    'Revision Date    : ',TRIM(revision_date)
+    write (iunit,'(A,A)')                    'Compiler         : ',TRIM(COMPILER_VERSION())
     write (iunit,'(A,A/)')                   'Compilation Date : ',TRIM(compile_date)
     return
 


### PR DESCRIPTION
Hi,

This PR adds compiler information to the CFAST output header using `COMPILER_VERSION()` from `iso_fortran_env`, similar to what [FDS ](https://github.com/firemodels/fds/blob/c5454055e6f8bfff88f76c9dd49d8c5a0ce2c3e9/Source/func.f90#L6691) has. I think it's useful to have this info in the header to facilitate debugging and reproducibility.

results:
```
CFAST

Test CFAST 7.7.5
Revision         : -feat/add-compiler-version
Revision Date    : Thu Feb 26 21:22:47 2026 +0100
Compiler         : GCC version 13.3.0
Compilation Date : Feb 26, 2026  21:27:09

Normal exit from CFAST
```