### PR TITLE
CFAST Validation: fix typos in Hawaii file

### DIFF
--- a/Validation/High_Bay/USN_Hawaii_Test_07.in
+++ b/Validation/High_Bay/USN_Hawaii_Test_07.in
@@ -1,4 +1,4 @@
-&HEAD VERSION = 7600, TITLE = 'HawaiiTest 5' /
+&HEAD VERSION = 7600, TITLE = 'HawaiiTest 7' /
  
 !! Scenario Configuration 
 &TIME SIMULATION = 740 PRINT = 50 SMOKEVIEW = 10 SPREADSHEET = 10 / 

--- a/Validation/High_Bay/USN_Hawaii_Test_11.in
+++ b/Validation/High_Bay/USN_Hawaii_Test_11.in
@@ -1,4 +1,4 @@
-&HEAD VERSION = 7600, TITLE = 'HawaiiTest 5' /
+&HEAD VERSION = 7600, TITLE = 'HawaiiTest 11' /
  
 !! Scenario Configuration 
 &TIME SIMULATION = 700 PRINT = 50 SMOKEVIEW = 10 SPREADSHEET = 10 / 


### PR DESCRIPTION
Same as the previous PR but for `HawaiiTest` Validation file.