### PR TITLE
CData: fix bug in FIRE_DO_RAND

### DIFF
--- a/Build/CData/makefile
+++ b/Build/CData/makefile
@@ -134,7 +134,7 @@ gnu_linux : $(objfgnu)
 	$(FCOMPL) $(FFLAGS) -o $(obj) $(objfgnu)
 
 # gnu linux debug
-gnu_linux_db : FFLAGS = -O0 -std=f2018 -ggdb -finit-real=snan -finit-integer=-999999 -Wall -Werror -Wunused-parameter -Wno-target-lifetime -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow -frecursive -ffpe-summary=none -fall-intrinsics -fbounds-check $(GITINFOGNU)
+gnu_linux_db : FFLAGS = -O0 -std=f2018 -ggdb -finit-real=snan -finit-integer=-999999 -Wall -Werror -Wunused-parameter -Wno-target-lifetime -Wno-surprising -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none -fall-intrinsics -fbounds-check $(GITINFOGNU)
 gnu_linux_db : FCOMPL = gfortran
 gnu_linux_db : LFLAGS = 
 gnu_linux_db : obj = cdata7_linux_db
@@ -168,7 +168,7 @@ gnu_osx : $(objfgnu)
 	$(FCOMPL) $(FFLAGS) -o $(obj) $(objfgnu)
 
 # gnu osx_db
-gnu_osx_db : FFLAGS = -O0 -std=f2018 -ggdb -finit-real=snan -finit-integer=-999999 -Wall -Werror -Wunused-parameter -Wno-target-lifetime -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow -frecursive -ffpe-summary=none -fall-intrinsics -fbounds-check $(GITINFOGNU)
+gnu_osx_db : FFLAGS = -O0 -std=f2018 -ggdb -finit-real=snan -finit-integer=-999999 -Wall -Werror -Wunused-parameter -Wno-target-lifetime -Wno-surprising -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none -fall-intrinsics -fbounds-check $(GITINFOGNU)
 gnu_osx_db : FCOMPL = gfortran
 gnu_osx_db : LFLAGS = 
 gnu_osx_db : obj = cdata7_osx_db

--- a/Source/Cdata/cdata_preprocessor.f90
+++ b/Source/Cdata/cdata_preprocessor.f90
@@ -25,7 +25,7 @@ module preprocessor_routines
         mxiterations, set_current_rng_seed_from_cdata
     use montecarlo_data, only: generatorinfo, n_generators, fieldinfo, n_fields, mc_write_seeds, mc_number_of_cases, &
         n_rndfires, randfireinfo, mc_max_iterations, workpath, parameterfile, fieldptr, validation_output
-    use preprocessor_types, only: random_generator_type
+    use preprocessor_types, only: field_pointer, fire_generator_type, random_generator_type
     
     !------------------------CData routines-------------------------------------
     use montecarlo_routines, only: create_mc_filename, process_mc_filename_pattern
@@ -87,7 +87,6 @@ module preprocessor_routines
     
     subroutine preprocessor_initialize
     
-    integer :: i, j, k
     integer, parameter :: i1 = 5554803, i2 = 7033951, c = 4*214783398 + 1
     integer :: values(8)
     character(len=10) :: date, time, zone
@@ -109,104 +108,145 @@ module preprocessor_routines
     rnd_seeds(1) = mod((rnd_seeds(1)+restart_values(7))*restart_values(8),restart_values(9))
     call set_current_rng_seed_from_cdata(rnd_seeds)
     mc_write_seeds = .false.
-    
+
     mc_max_iterations = mxiterations
     validation_output = validation_flag
-    
+
+    call allocate_generator_info
+    call allocate_field_info
+    call allocate_random_fire_info
+
+    return
+
+    end subroutine preprocessor_initialize
+
+    subroutine allocate_generator_info
+
+    integer :: i
+
     n_generators = 0
     allocate(generatorinfo(mxgenerators))
-    generatorinfo(1:mxgenerators)%id = 'NULL'
-    generatorinfo(1:mxgenerators)%fyi = 'NULL' 
-    generatorinfo(1:mxgenerators)%type_dist = 'NONE'
-    generatorinfo(1:mxgenerators)%value_type = 'NONE'
     do i = 1, mxgenerators
-        generatorinfo(i)%char_array(1:mxpntsarray) = 'NULL'
-        generatorinfo(i)%real_array(1:mxpntsarray) = -1001._eb 
-        generatorinfo(i)%int_array(1:mxpntsarray) = -1001  
-        generatorinfo(i)%logic_array(1:mxpntsarray) = .false.
-        generatorinfo(i)%prob_array(1:mxpntsarray) = -1001._eb 
-        generatorinfo(i)%seeds = -1001
-        call generatorinfo(i)%set_max_value(d1mach(2))
-        call generatorinfo(i)%set_min_value(-d1mach(2))
-        call generatorinfo(i)%set_add_value(0.0_eb)
-        generatorinfo(i)%max_offset = 0.0_eb
-        generatorinfo(i)%min_offset = 0.0_eb
+        call initialize_generator(generatorinfo(i))
     end do
-    generatorinfo(1:mxgenerators)%mean = 0._eb
-    generatorinfo(1:mxgenerators)%stdev = 0._eb
-    generatorinfo(1:mxgenerators)%alpha = 0._eb
-    generatorinfo(1:mxgenerators)%beta = 0._eb
-    generatorinfo(1:mxgenerators)%peak = 0._eb
-    generatorinfo(1:mxgenerators)%first = .true.
-    generatorinfo(1:mxgenerators)%use_seeds = .false.
-    
+
+    end subroutine allocate_generator_info
+
+    subroutine allocate_field_info
+
+    integer :: i
+
     n_fields = 0
     allocate(fieldinfo(mxfields))
-    fieldinfo(1:mxfields)%id = 'NULL'
-    fieldinfo(1:mxfields)%fyi = 'NULL'
-    fieldinfo(1:mxfields)%add_to_parameters = .false.
-    fieldinfo(1:mxfields)%parameter_column_label = 'NULL'
-    fieldinfo(1:mxfields)%position = 1
-    fieldinfo(1:mxfields)%temp_flag = .false.
-    fieldinfo(1:mxfields)%kilo_flag = .false. 
-    fieldinfo(1:mxfields)%press_flag = .false. 
     do i = 1, mxfields
-        fieldinfo(i)%real_array(1:mxpntsarray) = -1001.0_eb
-        fieldinfo(i)%int_array(1:mxpntsarray) = -1001
-        fieldinfo(i)%logic_array(1:mxpntsarray) = .false.
-        fieldinfo(i)%char_array(1:mxpntsarray) = 'NULL'
-        fieldinfo(i)%randptr%val => fieldinfo(i)%rand_value
+        call initialize_field(fieldinfo(i))
     end do
     allocate(fieldptr(mxfields))
     fieldptr(1:mxfields) = -1001
-    
-    
+
+    end subroutine allocate_field_info
+
+    subroutine allocate_random_fire_info
+
+    integer :: i
+
     n_rndfires = 0
     allocate(randfireinfo(mxrandfires))
-    randfireinfo(1:mxrandfires)%id = 'NULL'
-    randfireinfo(1:mxrandfires)%fireid = 'NULL'
-    randfireinfo(1:mxrandfires)%basefireid = 'NULL'
-    randfireinfo(1:mxrandfires)%hrrscalegenid = 'NULL'
-    randfireinfo(1:mxrandfires)%timescalegenid = 'NULL'
-    randfireinfo(1:mxrandfires)%smoldergenid = 'NULL'
-    randfireinfo(1:mxrandfires)%smoldertimegenid = 'NULL'
     do i = 1, mxrandfires
-        randfireinfo(i)%compname(1:mxrooms) = 'NULL'
-        randfireinfo(i)%compindex(1:mxrooms) = -1001
+        call initialize_random_fire(randfireinfo(i))
     end do
-    randfireinfo(1:mxrandfires)%generate_fire = .false.
-    randfireinfo(1:mxrandfires)%first_time_point_smoldering = .false.
-    randfireinfo(1:mxrandfires)%modifyfirearea = .false.
-    randfireinfo(1:mxrandfires)%scalehrr = .false.
-    randfireinfo(1:mxrandfires)%scaletime = .false.
-    randfireinfo(1:mxrandfires)%dostime = .false. 
-    randfireinfo(1:mxrandfires)%smoldering_fire = .false. 
-    randfireinfo(1:mxrandfires)%hrrscalevalue = -1001.0_eb
-    randfireinfo(1:mxrandfires)%timescalevalue = -1001.0_eb
-    randfireinfo(1:mxrandfires)%stimevalue = -1001.0_eb
-    do i = 1, mxrandfires
-        do j = 1, 2
-            do k = 1, mxpts
-                randfireinfo(i)%firegenerators(j, k)%id = 'NULL'
-                randfireinfo(i)%firegenerators(j, k)%fyi = 'NULL'
-                randfireinfo(i)%firegenerators(j, k)%add_to_parameters = .false.
-                randfireinfo(i)%firegenerators(j, k)%parameter_column_label = 'NULL'
-                randfireinfo(i)%firegenerators(j, k)%position = 1
-                randfireinfo(i)%firegenerators(j, k)%temp_flag = .false.
-                randfireinfo(i)%firegenerators(j, k)%kilo_flag = .false.
-                randfireinfo(i)%firegenerators(j, k)%real_array(1:mxpntsarray) = -1001.0_eb
-                randfireinfo(i)%firegenerators(j, k)%int_array(1:mxpntsarray) = -1001
-                randfireinfo(i)%firegenerators(j, k)%logic_array(1:mxpntsarray) = .false.
-                randfireinfo(i)%firegenerators(j, k)%char_array(1:mxpntsarray) = 'NULL'
-                randfireinfo(i)%firegenerators(j, k)%randptr%val => randfireinfo(i)%firegenerators(j, k)%rand_value
-            end do
+
+    end subroutine allocate_random_fire_info
+
+    subroutine initialize_generator(generator)
+
+    type(random_generator_type), target, intent(inout) :: generator
+
+    generator%id = 'NULL'
+    generator%fyi = 'NULL'
+    generator%type_dist = 'NONE'
+    generator%value_type = 'NONE'
+    if (.not. allocated(generator%char_array)) allocate(generator%char_array(mxpntsarray))
+    generator%char_array(1:mxpntsarray) = 'NULL'
+    generator%real_array(1:mxpntsarray) = -1001._eb
+    generator%int_array(1:mxpntsarray) = -1001
+    generator%logic_array(1:mxpntsarray) = .false.
+    generator%prob_array(1:mxpntsarray) = -1001._eb
+    generator%seeds = -1001
+    call generator%set_max_value(d1mach(2))
+    call generator%set_min_value(-d1mach(2))
+    call generator%set_add_value(0.0_eb)
+    generator%max_offset = 0.0_eb
+    generator%min_offset = 0.0_eb
+    generator%mean = 0._eb
+    generator%stdev = 0._eb
+    generator%alpha = 0._eb
+    generator%beta = 0._eb
+    generator%peak = 0._eb
+    generator%first = .true.
+    generator%use_seeds = .false.
+
+    end subroutine initialize_generator
+
+    subroutine initialize_field(field)
+
+    type(field_pointer), target, intent(inout) :: field
+
+    field%id = 'NULL'
+    field%fyi = 'NULL'
+    field%add_to_parameters = .false.
+    field%parameter_column_label = 'NULL'
+    field%position = 1
+    field%temp_flag = .false.
+    field%kilo_flag = .false.
+    field%press_flag = .false.
+    field%real_array(1:mxpntsarray) = -1001.0_eb
+    field%int_array(1:mxpntsarray) = -1001
+    field%logic_array(1:mxpntsarray) = .false.
+    if (.not. allocated(field%char_array)) allocate(field%char_array(mxpntsarray))
+    field%char_array(1:mxpntsarray) = 'NULL'
+    field%randptr%val => field%rand_value
+
+    end subroutine initialize_field
+
+    subroutine initialize_random_fire(random_fire)
+
+    type(fire_generator_type), target, intent(inout) :: random_fire
+    integer :: j, k
+
+    random_fire%id = 'NULL'
+    random_fire%fireid = 'NULL'
+    random_fire%basefireid = 'NULL'
+    random_fire%hrrscalegenid = 'NULL'
+    random_fire%timescalegenid = 'NULL'
+    random_fire%smoldergenid = 'NULL'
+    random_fire%smoldertimegenid = 'NULL'
+    random_fire%compname(1:mxrooms) = 'NULL'
+    random_fire%compindex(1:mxrooms) = -1001
+    random_fire%generate_fire = .false.
+    random_fire%first_time_point_smoldering = .false.
+    random_fire%modifyfirearea = .false.
+    random_fire%scalehrr = .false.
+    random_fire%scaletime = .false.
+    random_fire%dostime = .false.
+    random_fire%smoldering_fire = .false.
+    random_fire%hrrscalevalue = -1001.0_eb
+    random_fire%timescalevalue = -1001.0_eb
+    random_fire%stimevalue = -1001.0_eb
+    call initialize_field(random_fire%fire_comp)
+    call initialize_field(random_fire%fire_label)
+    call initialize_field(random_fire%fs_fire_ptr)
+    call initialize_field(random_fire%smolder_hrr_ptr)
+    call initialize_field(random_fire%flame_hrr_ptr)
+    call initialize_field(random_fire%smolder_time_ptr)
+    call initialize_field(random_fire%flame_time_ptr)
+    do j = 1, 2
+        do k = 1, mxpts
+            call initialize_field(random_fire%firegenerators(j, k))
         end do
     end do
-    
-    
-    return
-    
-    end subroutine preprocessor_initialize
+
+    end subroutine initialize_random_fire
     
     !
     !-------------------create_case---------------------------

--- a/Source/Cdata/cdata_structures.f90
+++ b/Source/Cdata/cdata_structures.f90
@@ -96,7 +96,7 @@ module preprocessor_types
         real(eb), dimension(mxpntsarray) :: real_array
         integer, dimension(mxpntsarray) :: int_array
         logical, dimension(mxpntsarray) :: logic_array
-        character(len=128), dimension(mxpntsarray) :: char_array
+        character(len=128), allocatable, dimension(:) :: char_array
         character(len=128) :: labelval
         logical :: conditional_min, conditional_max
         integer :: position
@@ -132,7 +132,7 @@ module preprocessor_types
                                                         !           CONSTANT, VALUE
         character(len=9) :: value_type                  ! what value type the generator produces: CHARACTER, REAL, INTEGER, 
                                                         !           LOGICAL
-        character(len=128) :: char_array(mxpntsarray)   ! values for discrete distributions with string type
+        character(len=128), allocatable :: char_array(:) ! values for discrete distributions with string type
         integer :: num_discrete_values                  ! number of values in arrays for discrere probablities 
         real(eb) :: real_array(mxpntsarray)             ! values for discrete distributions with real type
         integer :: int_array(mxpntsarray)               ! values for discrete distributions with integer type
@@ -1139,7 +1139,7 @@ module preprocessor_types
         integer, intent(in) :: iteration
         
         type(table_type),   pointer :: tablptr
-        integer :: i, tmp1
+        integer :: i, first_generated_pt, last_generated_pt, tmp1
         real(eb) :: deltat, a, b, c, t1, t0, tmp
         
         if (me%copy_base_to_fire) then
@@ -1204,10 +1204,16 @@ module preprocessor_types
         if (trim(me%incipient_type) /= trim(me%incip_typ(me%idx_none))) tmp1 = 1
         
         if (me%generate_fire) then
-            do i = 1, me%n_firepoints
+            first_generated_pt = me%last_growth_pt + 1
+            last_generated_pt = me%last_growth_pt + me%n_firegenerators
+            do i = first_generated_pt, last_generated_pt
                 call me%firegenerators(1,i)%do_rand(iteration)
                 call me%firegenerators(2,i)%do_rand(iteration)
             end do
+            if (me%decay_npts > 0) then
+                call me%firegenerators(1,me%n_firepoints)%do_rand(iteration)
+                call me%firegenerators(2,me%n_firepoints)%do_rand(iteration)
+            end if
             if (me%growth_npts > 0) then
                 if (.not. me%fire_generator_is_time_to_1054_kW) then
                     t1 = me%firegenerators(2,me%last_growth_pt+1)%realval%val


### PR DESCRIPTION
This fixes the CData crash reported in #2151 when running:

```bash
cdata Simple.in -P
```

The immediate crash was in `FIRE_DO_RAND`. The random fire logic was calling `do_rand` for every fire point, including fixed/base fire points that are not connected to random generators. The fix limits randomization to the generated fire points, plus the generated decay endpoint when present, so CData no longer dereferences an unassociated generator pointer.

While testing with GNU debug builds, we also found a separate stack-size problem in CData initialization. `randfireinfo` contains a large array of field-pointer objects, and each field pointer had a fixed-size string array. That caused a very large stack frame during preprocessor initialization. The string arrays are now allocatable and initialized explicitly, and the preprocessor initialization was split into smaller helper routines.

The CData GNU debug flags were also adjusted to avoid forcing large automatic storage onto the stack:

- removed `-frecursive`
- added `-Wno-surprising`

Verified with `gnu_osx_db`:

- `Simple.in -P` now creates 3 CFAST input files and exits normally.
- Other randomized CData examples tested successfully: `Detectors.in`, `Flashover.in`, and `Sensitivity.in`.