### PR TITLE
CData: address write_value issue in _parameters.csv

### DIFF
--- a/Source/CFAST/cfastexit.f90
+++ b/Source/CFAST/cfastexit.f90
@@ -176,10 +176,10 @@ module exit_routines
     
     subroutine closeoutputfiles
 
-    !	closeoutputfile closes units from open_output_files
-    !	Unit numbers defined here and read_input_file
+    ! closeoutputfile closes units from open_output_files
+    ! Unit numbers defined here and read_input_file
 
-    !	Unit numbers defined for various I/O purposes
+    ! Unit numbers defined for various I/O purposes
     !
     !     iofili        solver.ini and data files (data file, tpp and objects)
     !     iofill        log file
@@ -202,66 +202,45 @@ module exit_routines
     logical :: openunit
 
     ! first the file for "printed" output
-    inquire (iofilo, opened=openunit)
-    if(openunit) then
-        close(iofilo)
-    end if
+    call close_if_open(iofilo)
 
     ! the status files
-    inquire (iofilstat, opened=openunit)
-    if(openunit) then
-        close(iofilstat)
-    end if
+    call close_if_open(iofilstat)
 
     ! the smokeview files
     if (smv_out_interval>0) then
-        inquire(iofilsmv, opened=openunit)
-        if (openunit) then
-            close(iofilsmv)
-        end if
-        inquire(iofilsmvplt, opened=openunit)
-        if (openunit) then
-            close(iofilsmvplt)
-        end if
-        inquire(iofilsmvzone, opened=openunit)
-        if (openunit) then
-            close(iofilsmvzone)
-        end if
+        call close_if_open(iofilsmv)
+        call close_if_open(iofilsmvplt)
+        call close_if_open(iofilsmvzone)
     end if
 
     ! the spread sheet files
     if (ss_out_interval>0) then
         ! compartments spreadsheet
-        inquire(iofilssc, opened=openunit)
-        if(openunit) then
-            close(iofilssc)
-        end if
+        call close_if_open(iofilssc)
         ! devices spreadsheet
-        inquire(iofilssd, opened=openunit)
-        if (openunit) then
-            close(iofilssd)
-        end if
+        call close_if_open(iofilssd)
         ! masses spreadsheet
-        inquire(iofilssm, opened=openunit)
-        if (openunit) then
-            close(iofilssm)
-        end if
+        call close_if_open(iofilssm)
         ! vents spreadsheet
-        inquire(iofilssv, opened=openunit)
-        if (openunit) then 
-            close(iofilssv)
-        end if
+        call close_if_open(iofilssv)
         ! diagnostic spreadsheet
-        inquire(iofilssdiag, opened=openunit)
-        if (openunit) then
-            close(iofilssdiag)
-        end if
+        call close_if_open(iofilssdiag)
         ! calculations spreadhseet
-        inquire(iofilcalc, opened=openunit)
-        if (openunit) then
-            close(iofilcalc)
-        end if
+        call close_if_open(iofilcalc)
     end if 
+
+    contains
+
+    subroutine close_if_open(unit)
+
+    integer, intent(in) :: unit
+
+    if (unit<=0) return
+    inquire(unit, opened=openunit)
+    if (openunit) close(unit)
+
+    end subroutine close_if_open
     
     end subroutine closeoutputfiles
     

--- a/Source/CFAST/input.f90
+++ b/Source/CFAST/input.f90
@@ -44,10 +44,12 @@
 
 !> \brief   read the input file and set up the data for processing
 
-    subroutine read_input_file ()
+    subroutine read_input_file (open_outputs)
 
     implicit none
 
+    logical, intent(in), optional :: open_outputs
+    logical :: do_open_outputs
     real(eb) :: temparea(mxpts), temphgt(mxpts), deps1, dwall1, dwall2, rti
     real(eb) :: xloc, yloc, zloc, zbot, ztop, pyramid_height, dheight, xx, sum
     integer :: ios, i, ii, j, itop, ibot, nswall2, iroom, iroom1, iroom2
@@ -59,6 +61,9 @@
     type(target_type), pointer :: targptr
     type(material_type), pointer :: thrmpptr
     type(vent_type), pointer :: ventptr    
+
+    do_open_outputs = .true.
+    if (present(open_outputs)) do_open_outputs = open_outputs
 
     ! deal with opening the data file and assuring ourselves that it is compatible
     close (iofili)
@@ -118,7 +123,7 @@
     end do
 
     ! we now know what output is going to be generated, so create the files
-    call open_output_files
+    if (do_open_outputs) call open_output_files
 
     interior_rho = interior_abs_pressure/interior_ambient_temperature/rgas
     exterior_rho = exterior_abs_pressure/exterior_ambient_temperature/rgas
@@ -651,7 +656,7 @@
         if (ilen>0) then
             xname = buf
 
-            !	Split out the components
+            ! Split out the components
             drive(i) = ' '
             dir(i) = ' '
             name(i) = ' '
@@ -682,7 +687,7 @@
 
     inquire (file=buf(1:len_trim(buf)), exist=doesthefileexist)
     if (doesthefileexist) then
-        !	The project file exists
+        ! The project file exists
         exepath = drive(1)(1:ld(1)) // dir(1)(1:li(1))
         datapath = drive(2)(1:ld(2)) // dir(2)(1:li(2))
         project = name(2)(1:ln(2))

--- a/Source/Cdata/cdata_preprocessor.f90
+++ b/Source/Cdata/cdata_preprocessor.f90
@@ -57,7 +57,7 @@ module preprocessor_routines
     call read_command_options
     call open_files
 
-    call read_input_file
+    call read_input_file(.false.)
     
     call preprocessor_initialize
     call cdata_preprocessor_rereadinputfile
@@ -260,11 +260,11 @@ module preprocessor_routines
     call add_filename_to_parameters(filename)
     do i = 1, n_rndfires
         call randfireinfo(i)%do_rand(iteration)
-        !call randfireinfo(i)%write_value
+        call randfireinfo(i)%write_value
     end do 
     do i = 1, n_fields
         call fieldinfo(fieldptr(i))%do_rand(iteration)
-        !call fieldinfo(fieldptr(i))%write_value
+        call fieldinfo(fieldptr(i))%write_value
     end do 
     
     end subroutine create_case

--- a/Source/Cdata/cdata_structures.f90
+++ b/Source/Cdata/cdata_structures.f90
@@ -44,6 +44,7 @@ module preprocessor_types
         logical :: temp_flag = .false., kilo_flag = .false., press_flag = .false.
     contains
         procedure :: add_header
+        procedure :: write_value
     end type value_wrapper_type
     
     type, extends(value_wrapper_type) :: random_char_type
@@ -544,6 +545,86 @@ module preprocessor_types
         
     end subroutine add_header
     
+    !
+    !--------write_value---------
+    !
+
+    recursive subroutine write_value(me)
+
+        class(value_wrapper_type), intent(inout) :: me
+
+        integer :: i
+        real(eb) :: tmp
+
+        if (me%add_to_parameters .and. me%parameter_field_set) then
+            select type (me)
+            type is (value_wrapper_type)
+                write(me%paramptr, '(a)') 'Values not set'
+            type is (random_real_type)
+                if (me%temp_flag) then
+                    tmp = me%val - kelvin_c_offset
+                else if (me%kilo_flag) then
+                    tmp = me%val/1000.0_eb
+                else if (me%press_flag) then
+                    tmp = me%val + pressure_offset
+                else
+                    tmp = me%val
+                end if
+                write(me%paramptr, '(e13.6)') tmp
+            type is (random_int_type)
+                write(me%paramptr, '(i10)') me%val
+            type is (random_char_type)
+                write(me%paramptr, '(a)') me%val
+            type is (random_logic_type)
+                if (me%val) then
+                    write(me%paramptr, '(a)') '.TRUE.'
+                else
+                    write(me%paramptr, '(a)') '.FALSE.'
+                end if
+            type is (field_pointer)
+                select case (me%value_type)
+                case ('NULL')
+                    call me%errorcall('write_value', 1)
+                case (val_types(idx_real))
+                    if (me%temp_flag) then
+                        tmp = me%realval%val - kelvin_c_offset
+                    else if (me%kilo_flag) then
+                        tmp = me%realval%val/1000.0_eb
+                    else if (me%press_flag) then
+                        tmp = me%realval%val + pressure_offset
+                    else
+                        tmp = me%realval%val
+                    end if
+                    write(me%paramptr, '(e13.6)') tmp
+                case (val_types(idx_int))
+                    write(me%paramptr, '(i10)') me%intval%val
+                case (val_types(idx_char))
+                    write(me%paramptr, '(a)') me%charval%val
+                case (val_types(idx_logic))
+                    if (me%logicval%val) then
+                        write(me%paramptr, '(a)') '.TRUE.'
+                    else
+                        write(me%paramptr, '(a)') '.FALSE.'
+                    end if
+                case default
+                    call me%errorcall('write_value', 2)
+                end select
+            type is (fire_generator_type)
+                call me%hrrscaleval%write_value
+                call me%timescaleval%write_value
+                call me%fire_label%write_value
+                call me%fs_fire_ptr%write_value
+                do i = 1, me%n_firepoints
+                    call me%firegenerators(2, i)%write_value
+                    call me%firegenerators(1, i)%write_value
+                end do
+            class default
+                call me%errorcall('write_value', 3)
+            end select
+        end if
+
+    end subroutine write_value
+
     !
     !------do_rand--------------
     !


### PR DESCRIPTION
This fixes the CData behavior reported in Discussion [#2331](https://github.com/firemodels/cfast/discussions/2331) where `Simple_parameters.csv` was created with the expected headers and case names, but the randomized parameter values were blank.

Root cause: the CData parameter-output path had been disconnected in commit `7264729eb` (`CData: fixed error in write and removed unused code`). In that change, the calls to `write_value` in `create_case` were commented out. Because those calls were no longer active, the `write_value` routine later appeared unused and was removed. The result was that CData still created the parameter CSV header row with `add_header`, but never copied each generated case’s sampled values into the row before `flush_parameters_buffer`.

The fix restores that missing path:

- Restored the type-bound `write_value` routine for `value_wrapper_type`.
- Re-enabled the `write_value` calls after each random fire and field is randomized in `create_case`.
- Kept the newer `FIRE_DO_RAND` behavior that avoids randomizing unassociated fire-generator points, so the previous CData crash fix remains intact.
- Changed CData’s initial input read to call `read_input_file(.false.)`, so preprocessing does not create empty base-case CFAST output files such as `Simple_vents.csv` while running `cdata Simple.in -P`.

After this change, running:

```bash
cdata Simple.in -P