### PR TITLE
CFAST ceditqt: fix permisison error try 2 Issue #2425

### DIFF
--- a/Source/CeditQt/main_window.py
+++ b/Source/CeditQt/main_window.py
@@ -1470,18 +1470,17 @@ class CeditMainWindow(QMainWindow):
     def poll_cfast_status(self):
         if self.cfast_status_path is None or not self.cfast_status_path.exists():
             return
-        for qq in range(3):
+        try:
+            text = self.cfast_status_path.read_text(
+                encoding="utf-8",
+                errors="replace",
+            ).strip()
+            break
+        except PermissionError:
+           return
+        except OSError:
+            return
 
-           try:
-               text = self.cfast_status_path.read_text(
-                   encoding="utf-8",
-                   errors="replace",
-               ).strip()
-           except PermissionError:
-              time.sleep(0.01)
-           except OSError:
-               return
-           text = self.cfast_status_path.read_text(encoding="utf-8",errors="replace",).strip()
         if not text:
             return
 


### PR DESCRIPTION
This fix checks for a permission error when updating the status. If one happens it skips that check. Worst case is the screen log goes a little longer without updates but cfast won't crash out.